### PR TITLE
Fix PhaseAligner.js

### DIFF
--- a/src/audio/processors/PhaseAligner.js
+++ b/src/audio/processors/PhaseAligner.js
@@ -28,8 +28,8 @@ export class PhaseAligner {
     // Cross-correlation for phase alignment
     const crossCorrelation = new Float32Array(signal.length);
     for (let i = 0; i < signal.length; i++) {
-      for (let j = 0; j < reference.length; j++) {
-        crossCorrelation[i] += signal[j] * reference[(j + i) % reference.length];
+      for (let j = 0; j < reference.getChannelData(0).length; j++) {
+        crossCorrelation[i] += signal[j] * reference.getChannelData(0)[(j + i) % reference.getChannelData(0).length];
       }
     }
     return new Tone.Buffer().fromArray(crossCorrelation);


### PR DESCRIPTION
The `calculateImpulseResponse` method in `PhaseAligner.js` was using `referenceSignal.length` and `referenceSignal[i]` to access data from an `AudioBuffer`. This is incorrect because `AudioBuffer`s do not have a `length` property and cannot be accessed by index.

This commit fixes the issue by using `referenceSignal.getChannelData(0).length` and `referenceSignal.getChannelData(0)[i]` instead.